### PR TITLE
Stage to Main

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "ssv-web-next",
-  "private": true,
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/src/hooks/use-links.ts
+++ b/src/hooks/use-links.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 import { useAccount } from "@/hooks/account/use-account";
 
-const isProduction = location.hostname === "app.ssv.network"; // TODO: determine production through build.yaml
+const isProduction = location.hostname === "app.ssv.network"; // TODO: determine production through build.yaml environment variable
 
 export const useLinks = () => {
   const { chain } = useAccount();
@@ -13,7 +13,7 @@ export const useLinks = () => {
       launchpad: `https://${prefix}launchpad.ethereum.org`,
       etherscan: `https://${prefix}etherscan.io`,
       ssv: {
-        explorer: `https://explorer${ssvPrefix}.ssv.network`,
+        explorer: `https://${isProduction ? prefix : ""}explorer${ssvPrefix}.ssv.network`,
         docs: `https://docs.ssv.network`,
         forum: `https://forum.ssv.network/`,
         governanceForum: `https://forum.ssv.network/`,

--- a/src/lib/contract-interactions/utils/useWaitForTransactionReceipt.tsx
+++ b/src/lib/contract-interactions/utils/useWaitForTransactionReceipt.tsx
@@ -48,15 +48,16 @@ export const withTransactionModal = <
 >(
   options?: T,
 ) => {
-  const isContract = isContractWallet();
   return {
     onInitiated: () => {
+      const isContract = isContractWallet();
       options?.onInitiated?.();
       if (isContract) {
         useMultisigTransactionModal.state.open();
       }
     },
     onConfirmed: async (hash) => {
+      const isContract = isContractWallet();
       if (isContract) {
         useMultisigTransactionModal.state.open();
       } else {


### PR DESCRIPTION
* fixed flag to disable max validators validation (#1163)

* Da/flag fix (#1165)

* fixed flag to disable max validators validation

* added flag for keyShares validation

* fix: mixpanel country with ip true

* Point ssv-web to the api in Civo (#1161)

* Point ssv-web to the api in Civo

* Updated .env.development file

* build(next-version): merging next version into the old one

* fix: semantic-release on every branch

* fix: semantic-release

* ci: removed @semantic-release/release-notes-generator

* chore(release): 1.0.0-sumbat-dev.1 [skip ci]

# 1.0.0-sumbat-dev.1 (2024-09-22)

### Bug Fixes

* 571, 573, changed whitelist texts ([#943](https://github.com/ssvlabs/ssv-web/issues/943)) ([8e09d41](https://github.com/ssvlabs/ssv-web/commit/8e09d41091b8ddf5676a69dd3e423c642ad10740))
* added buffer, and http://localhost:5173 to CSP ([#850](https://github.com/ssvlabs/ssv-web/issues/850)) ([cdea487](https://github.com/ssvlabs/ssv-web/commit/cdea487077dcccc340a6342f5d9656c5180d299d))
* added darkmode styles to rainbowkit ([#880](https://github.com/ssvlabs/ssv-web/issues/880)) ([e9731ed](https://github.com/ssvlabs/ssv-web/commit/e9731ed82e23fb00f5010e51dbe1c2fae070e227))
* added layout pb ([16984bf](https://github.com/ssvlabs/ssv-web/commit/16984bf4eeae0117215de3c8f3b1c3063ced9448))
* added missing imports ([#872](https://github.com/ssvlabs/ssv-web/issues/872)) ([dbb4896](https://github.com/ssvlabs/ssv-web/commit/dbb4896049c11fcdc294f671f8f5b19239be8620))
* added optimistic operators to operator picker ([#1097](https://github.com/ssvlabs/ssv-web/issues/1097)) ([9307e91](https://github.com/ssvlabs/ssv-web/commit/9307e918ee1bf4b5afac8d2ed8c70f6b6cf16bf3))
* added type to the TextInput cmp ([#875](https://github.com/ssvlabs/ssv-web/issues/875)) ([897aa87](https://github.com/ssvlabs/ssv-web/commit/897aa87a76d2a14f502bdb6870549f3ed316993c))
* address check for external contract ([#1006](https://github.com/ssvlabs/ssv-web/issues/1006)) ([f346f77](https://github.com/ssvlabs/ssv-web/commit/f346f7783d75a448b74f20d5356317f13921eae0))
* blank page on withdraw ([#1017](https://github.com/ssvlabs/ssv-web/issues/1017)) ([eb104bc](https://github.com/ssvlabs/ssv-web/commit/eb104bc188bd2931a1b7df60d1b513af19dff264))
* checking if account can use operator ([cc2e748](https://github.com/ssvlabs/ssv-web/commit/cc2e7485452cb61986264dfdfa241fca8f7cc39f))
* cluster error ([#1076](https://github.com/ssvlabs/ssv-web/issues/1076)) ([9ba213a](https://github.com/ssvlabs/ssv-web/commit/9ba213a98a661d64e015180f78a675da83a79756))
* config issues and texts ([#1001](https://github.com/ssvlabs/ssv-web/issues/1001)) ([6b9614b](https://github.com/ssvlabs/ssv-web/commit/6b9614b161ac118fc50d4533ae084ae39c912875))
* disabled mixpanel ip ([#1113](https://github.com/ssvlabs/ssv-web/issues/1113)) ([d6494c8](https://github.com/ssvlabs/ssv-web/commit/d6494c8ffff403da64d6c4b19182e3b69ea08d37))
* external contract cancel button ([#986](https://github.com/ssvlabs/ssv-web/issues/986)) ([d663d2f](https://github.com/ssvlabs/ssv-web/commit/d663d2f4f831c9c9ef0ab69f87b273e961b07d32))
* external contract text's and tooltip behavior ([#982](https://github.com/ssvlabs/ssv-web/issues/982)) ([18d62c7](https://github.com/ssvlabs/ssv-web/commit/18d62c7c89e0d2345f71be6785005fcf798e6832))
* faucet error message ([3886eb6](https://github.com/ssvlabs/ssv-web/commit/3886eb64c75e280b01332d94df6c89939f16154e))
* fetchIsRegisteredValidator ([d11ca6b](https://github.com/ssvlabs/ssv-web/commit/d11ca6b1bb002d3c2ab26e845e052a3219198c17))
* font sizes and colors ([b155db3](https://github.com/ssvlabs/ssv-web/commit/b155db3447a94e30cca715494e001a770420b2d3))
* getSigner issue + ssvloader ([#852](https://github.com/ssvlabs/ssv-web/issues/852)) ([f9429a9](https://github.com/ssvlabs/ssv-web/commit/f9429a9b6274b12365f4ed7580a24e3e20384df8))
* increased node memory size for build ([#862](https://github.com/ssvlabs/ssv-web/issues/862)) ([b2003f3](https://github.com/ssvlabs/ssv-web/commit/b2003f3c7c1bc64b9db52cf0cc20c9d09c09b8b1))
* invalid tag ui ([#1026](https://github.com/ssvlabs/ssv-web/issues/1026)) ([296c598](https://github.com/ssvlabs/ssv-web/commit/296c5980674b575fed8c78c6432f3b999ca1637d))
* metamask connecting issue ([#886](https://github.com/ssvlabs/ssv-web/issues/886)) ([10af32e](https://github.com/ssvlabs/ssv-web/commit/10af32e8f286eaa7b489bd37d16cb831714d937a))
* mixpanel breaking the webapp ([#1132](https://github.com/ssvlabs/ssv-web/issues/1132)) ([8f2d567](https://github.com/ssvlabs/ssv-web/commit/8f2d567cb45079d50dfe8ba76a100f32cb8beb3c))
* mixpanel country with ip true ([db31c40](https://github.com/ssvlabs/ssv-web/commit/db31c4017da1faf18df837d3f19ed5e07599d1ec))
* mixpanel pre-stage ([#1131](https://github.com/ssvlabs/ssv-web/issues/1131)) ([1dfb1f4](https://github.com/ssvlabs/ssv-web/commit/1dfb1f497192df5fa56858288758520cdfd52a21))
* operator metadata signing issue ([#920](https://github.com/ssvlabs/ssv-web/issues/920)) ([55920b0](https://github.com/ssvlabs/ssv-web/commit/55920b087ac0a1e703257adf03f64abf9c42b12c))
* Operator placeholder ([8e24698](https://github.com/ssvlabs/ssv-web/commit/8e24698a2179609d34280ef5bf54836db213d134))
* operator search shows private operators ([#975](https://github.com/ssvlabs/ssv-web/issues/975)) ([f3809b1](https://github.com/ssvlabs/ssv-web/commit/f3809b17868f32669e6ceb0b58166ff3d4c74ff6))
* operators scroll issue ([#1091](https://github.com/ssvlabs/ssv-web/issues/1091)) ([7e351d7](https://github.com/ssvlabs/ssv-web/commit/7e351d7470cf8aca637d5cede86c9ad1819433b4))
* rejecting transaction issue ([#1108](https://github.com/ssvlabs/ssv-web/issues/1108)) ([9cfa9ad](https://github.com/ssvlabs/ssv-web/commit/9cfa9ad959f5dadd8e9a6af0aa967e763cfe8897))
* remove enrichOperator function from operator and cluster services ([#1014](https://github.com/ssvlabs/ssv-web/issues/1014)) ([ffd6e1f](https://github.com/ssvlabs/ssv-web/commit/ffd6e1ffbd4fdec631910846fa7b42a40375bfc6))
* removed desktop app and removed change operators button while loading dkg health ([#938](https://github.com/ssvlabs/ssv-web/issues/938)) ([80c1cc1](https://github.com/ssvlabs/ssv-web/commit/80c1cc159dfd6c5e6f97d0da2cc5facab2935831))
* removed unused regex ([e4bbe25](https://github.com/ssvlabs/ssv-web/commit/e4bbe25d422972db650ccc427e358975143c40b7))
* request from enriched operator instead of delaying the operator refresh ([#984](https://github.com/ssvlabs/ssv-web/issues/984)) ([1c2a155](https://github.com/ssvlabs/ssv-web/commit/1c2a15529a5c73023c6b2b4d899c37f2cef536f9))
* semantic-release ([ac51ecf](https://github.com/ssvlabs/ssv-web/commit/ac51ecf39296fe58d0ecbd3fabf2ec3ad9d768fa))
* semantic-release on every branch ([ca661f0](https://github.com/ssvlabs/ssv-web/commit/ca661f0daf12857ba0b232dad2de70d094b48a75))
* setFeeRecipient not showing loading for walletConnect ([02fb7d6](https://github.com/ssvlabs/ssv-web/commit/02fb7d6c2d61d82b082b6bc0fde4bce16f204d05))
* showing lock icon on cluster row + cluster.operators enrichment ([#978](https://github.com/ssvlabs/ssv-web/issues/978)) ([dbc277c](https://github.com/ssvlabs/ssv-web/commit/dbc277cd23e657a5834781c55d306534d6b499ef))
* small bugs and setSelectedOperator refactor ([#964](https://github.com/ssvlabs/ssv-web/issues/964)) ([ca5c8e5](https://github.com/ssvlabs/ssv-web/commit/ca5c8e5c7e820e5f4dd10b33da773589c4e05cdb))
* switching account in faucet ([#1039](https://github.com/ssvlabs/ssv-web/issues/1039)) ([82c1d6d](https://github.com/ssvlabs/ssv-web/commit/82c1d6d9550d168a30c8ffab4cef014ca038cc5d))
* toWei issue when passing numbers like 1e-7 ([77e889a](https://github.com/ssvlabs/ssv-web/commit/77e889ab903e210a5f805f6df82d85e6f9374f9a))
* transactionExecutor ([ee64bd5](https://github.com/ssvlabs/ssv-web/commit/ee64bd59e25332b6e4884d784fc9a570f4139100))
* undo rollback ([#957](https://github.com/ssvlabs/ssv-web/issues/957)) ([7e0b035](https://github.com/ssvlabs/ssv-web/commit/7e0b0350cf4bd33bd19ddc71ce04e576453e8306))
* wallet connect icon ([ea69091](https://github.com/ssvlabs/ssv-web/commit/ea690919bba25a833cc114843b163ddc7c2f4ab5))
* walletConnect pending tx issue ([#906](https://github.com/ssvlabs/ssv-web/issues/906)) ([762b327](https://github.com/ssvlabs/ssv-web/commit/762b3274a59663200f6e1e4eafd866683cf69b41))
* will prettify staged files before commit ([#877](https://github.com/ssvlabs/ssv-web/issues/877)) ([2c1d7a2](https://github.com/ssvlabs/ssv-web/commit/2c1d7a260d4a7eebb310d32bf572f640114978b6))

### Features

* checking operator dkg health ([5dadec4](https://github.com/ssvlabs/ssv-web/commit/5dadec4bfc073ca9a254122b5bbc95e8e4f2324e))

### Reverts

* Revert "Lazy loading for stores" ([57e25d6](https://github.com/ssvlabs/ssv-web/commit/57e25d6a4d3b15279ab550c0a4fb435b856aaff3))
* Revert "Lazy loading for stores" ([698d877](https://github.com/ssvlabs/ssv-web/commit/698d8773f0a429d506f65ecfc3328a8b7716fb38))
* Revert "Revert "Merge pull request [#944](https://github.com/ssvlabs/ssv-web/issues/944) from ssvlabs/INTERFACES-490-operator-metadata-store-refactor"" ([#1000](https://github.com/ssvlabs/ssv-web/issues/1000)) ([a27021e](https://github.com/ssvlabs/ssv-web/commit/a27021ea7c60214af44e7fd5242e505a7d1c1016))

* fix: testing version bumping

* ci: removed faucet

* fix: added chainId to all queryKeys

* style: reactivate button sizes

* fix: switching cluster page issue

* fix: new account logic

* fix: multisig transaction modal close button will redirect to the dashboard

* fix: refactored chainIds in queries

* fix: after multisig is confirmed we switch to default transaction modal

* fix: withTransactionModal

* fix: /join path cannot be accessed if the account has clusters/operators

* fix: added "createdOptimisticOperators" to account state

* fix: added release-notes-generator

* fix: ui design

* feat: added sentry.io

* fix: added mixpanel

* fix: removed sentry testing button

* fix: ui + redirection

* style: removed padding

* style: cluster table header font

* style: all headers font-bold

* chore: added missing space

* style: operator picker

* chore: mev relays

* style: fixed operator settings ui

* style: redesign

* style: small fixes

* fix: ui

* fix: new operator picture

* fix: operator metadata select component

* fix: refresh resets the flow

* fix: slashing warning

* fix: register validator guard

* fix: nonce checker

* chore: typo

* fix: fee recipient address tooltip url

* fix: operator creation issue

* fix: initial funding ui

* fix: initial funding custom option

* fix: clear keyshares file when clicking on cmd option

* style: form label doesn't change color on error

* fix: clickable button when disabled

* fix: reactive period options

* fix: url validator

* fix: join routes back button paths

* fix: file persistance issues

* fix: offline keyshares upload

* fix: cannot execute exit while liquidated

* fix: testing wagmi without rainbow kit

* fix: upgraded walletconnect version

* ci: prod-test use stage env

* ci: prod-test prod env

* fix: added gtm, refactored analytics folder

* fix: fee recipient address

* ci: reset version

* ci: prod-test, stage -> prerelease

* fix: number input 0 displayDecimals

* Deploy from pre-stage branch

* fix: number input regex

* Added env for app-pre.stage.ssv.network

* ci: pre-stage

* feat: compliance

* fix: percentage display

* fix: ui + dkg cmd network name

* fix: operator/cluster inputs design + 404 route

* fix: contract wallet transaction modal initiation

* style: estimated operational runway

* fix: compliance flag

* fix: private operator logic

* style: number input placeholders

* fix: lazy table logic + cleanup + filter out dkg with "http://"

* fix: mainnet_private_rpc_client

* fix: added back btn for dkg ceremony page

* fix: filter operators with https

* fix: reactivate funding number input

* fix: production explorer link

* fix: 404 page

* fix: link to explorer

* fix: package.json v2

* fix: bumped ssv-keys version

* fix: is-contract logic

* fix: rollback ssv-keys version

* fix: pnpm-lock

---------