### PR TITLE
Update CI workflow

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -4,15 +4,13 @@ on:
   push:
     branches:
       - "**"
-  pull_request:
-    branches:
-      - "**"
 
   workflow_dispatch:
 
 jobs:
   lint:
     permissions:
+      id-token: write
       contents: write
       issues: write
       pull-requests: write
@@ -99,7 +97,7 @@ jobs:
 
       # <app-pre.stage.ssv.network> pre-stage
       - name: Run stage webapp build
-        if: github.ref == 'refs/heads/pre-stage'
+        if: github.ref == 'refs/heads/pre-stage-update-ci'
         run: >
           GAS_PRICE="${{ env.GAS_PRICE }}"
           GAS_LIMIT="${{ env.GAS_LIMIT }}"
@@ -115,17 +113,17 @@ jobs:
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
 
-      - name: Deploy stage webapp
-        if: github.ref == 'refs/heads/pre-stage'
-        uses: jakejarvis/s3-sync-action@v0.5.0
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/pre-stage-update-ci'
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: "build/"
-          AWS_REGION: "us-west-2"
-          AWS_S3_BUCKET: ${{ secrets.STAGE_AWS_S3_BUCKET_PRE_STAGE }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGE_AWS_SECRET_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGE_AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.SSV_WEB_AWS_IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
+      - name: Upload files to S3
+        if: github.ref == 'refs/heads/pre-stage-update-ci'
+        run: |
+          aws s3 cp ./build s3://${{ secrets.SSV_WEB_PRE_STAGE_AWS_S3_BUCKET }} --recursive
       # </app-pre.stage.ssv.network>
 
       # <app.stage.ssv.network>
@@ -223,114 +221,4 @@ jobs:
           AWS_S3_BUCKET: ${{ secrets.PROD_AWS_S3_BUCKET_BA_APP }}
           AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_SECRET_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-      # </ba-app.ssv.network>
-
-      # <faucet.stage.ssv.network>
-      # - name: Run stage faucet build
-      #   if: github.ref == 'refs/heads/stage'
-      #   run: >
-      #     SSV_NETWORKS="${{ env.STAGE_SSV_NETWORKS }}"
-      #     GOOGLE_TAG_SECRET="$GOOGLE_TAG_SECRET"
-      #     EXPLORER_URL="$EXPLORER_URL" BLOCKNATIVE_KEY="$BLOCKNATIVE_KEY" pnpm build
-      #   env:
-      #     VITE_FAUCET_PAGE: "true"
-      #     SSV_NETWORKS: ${{ env.STAGE_SSV_NETWORKS }}
-      #     BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
-      #     EXPLORER_URL: "https://explorer.ssv.network/"
-      #     LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
-      #     VITE_CAPTCHA_KEY: ${{ secrets.CAPTCHA_KEY_STAGE }}
-
-      # - name: Deploy stage faucet
-      # if: github.ref == 'refs/heads/stage'
-      # uses: jakejarvis/s3-sync-action@v0.5.0
-      # with:
-      #   args: --acl public-read --follow-symlinks --delete
-      # env:
-      #   SOURCE_DIR: 'build/'
-      #   AWS_REGION: 'us-west-2'
-      #   AWS_S3_BUCKET: ${{ secrets.STAGE_FAUCET_AWS_S3_BUCKET }}
-      #   AWS_ACCESS_KEY_ID: ${{ secrets.STAGE_AWS_SECRET_KEY_ID }}
-      #   AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGE_AWS_SECRET_ACCESS_KEY }}
-      # </faucet.stage.ssv.network>
-
-      # <claim.stage.ssv.network>
-      #      - name: Run stage build claim
-      #        if: github.ref == 'refs/heads/stage'
-      #        run: >
-      #          SSV_NETWORKS="${{ env.STAGE_SSV_NETWORKS }}"
-      #          BLOCKNATIVE_KEY="$BLOCKNATIVE_KEY" PROD_CLAIM_PAGE="$PROD_CLAIM_PAGE" pnpm build
-      #        env:
-      #          PROD_CLAIM_PAGE: "true"
-      #          BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
-      #          LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
-      #          SSV_NETWORKS: ${{ env.STAGE_SSV_NETWORKS }}
-      #
-      #      - name: Deploy stage claim
-      #        if: github.ref == 'refs/heads/stage'
-      #        uses: jakejarvis/s3-sync-action@v0.5.0
-      #        with:
-      #          args: --acl public-read --follow-symlinks --delete
-      #        env:
-      #          SOURCE_DIR: 'build/'
-      #          AWS_REGION: 'us-west-2'
-      #          AWS_S3_BUCKET: ${{ secrets.STAGE_V2_AWS_S3_BUCKET_CLAIM }}
-      #          AWS_ACCESS_KEY_ID: ${{ secrets.STAGE_AWS_SECRET_KEY_ID }}
-      #          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGE_AWS_SECRET_ACCESS_KEY }}
-      # </claim.stage.ssv.network>
-
-      # <faucet.ssv.network>
-      # - name: Run prod faucet build
-      #   if: github.ref == 'refs/heads/main'
-      #   run: >
-      #     SSV_NETWORKS="${{ env.PROD_SSV_NETWORKS }}"
-      #     GOOGLE_TAG_SECRET="$GOOGLE_TAG_SECRET"
-      #     EXPLORER_URL="$EXPLORER_URL"
-      #     BLOCKNATIVE_KEY="$BLOCKNATIVE_KEY"
-      #     MIXPANEL_TOKEN_PROD="${{ secrets.MIXPANEL_TOKEN_PROD }}"
-      #     pnpm build
-      #   env:
-      #     VITE_FAUCET_PAGE: "true"
-      #     SSV_NETWORKS: ${{ env.PROD_SSV_NETWORKS }}
-      #     BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
-      #     EXPLORER_URL: "https://explorer.ssv.network/"
-      #     LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
-      #     VITE_CAPTCHA_KEY: ${{ secrets.CAPTCHA_KEY_STAGE }}
-      #     MIXPANEL_TOKEN_PROD: ${{ secrets.MIXPANEL_TOKEN_PROD }}
-
-      # - name: Deploy prod faucet
-      #   if: github.ref == 'refs/heads/main'
-      #   uses: jakejarvis/s3-sync-action@v0.5.0
-      #   with:
-      #     args: --acl public-read --follow-symlinks --delete
-      #   env:
-      #     SOURCE_DIR: 'build/'
-      #     AWS_REGION: 'us-west-2'
-      #     AWS_S3_BUCKET: ${{ secrets.PROD_FAUCET_AWS_S3_BUCKET }}
-      #     AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_SECRET_KEY_ID }}
-      #     AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-      # </faucet.ssv.network>
-
-      # <claim.ssv.network>
-      #      - name: Run prod build claim
-      #        if: github.ref == 'refs/heads/main'
-      #        run: >
-      #          SSV_NETWORKS="${{ env.PROD_SSV_NETWORKS }}"
-      #          BLOCKNATIVE_KEY="$BLOCKNATIVE_KEY" PROD_CLAIM_PAGE="$PROD_CLAIM_PAGE" pnpm build
-      #        env:
-      #          PROD_CLAIM_PAGE: "true"
-      #          BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
-      #          LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
-      #          SSV_NETWORKS: ${{ env.PROD_SSV_NETWORKS }}
-      #
-      #      - name: Deploy prod claim
-      #        if: github.ref == 'refs/heads/main'
-      #        uses: jakejarvis/s3-sync-action@v0.5.0
-      #        with:
-      #          args: --acl public-read --follow-symlinks --delete
-      #        env:
-      #          SOURCE_DIR: 'build/'
-      #          AWS_REGION: 'us-west-2'
-      #          AWS_S3_BUCKET: ${{ secrets.PROD_AWS_S3_BUCKET_CLAIM }}
-      #          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_SECRET_KEY_ID }}
-      #          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-      # </claim.ssv.network>
+       # </ba-app.ssv.network>

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
+  github-workflow:
     permissions:
       id-token: write
       contents: write
@@ -95,6 +95,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npx semantic-release
 
+      - name: Configure AWS credentials
+        if: github.ref == 'refs/heads/pre-stage-update-ci' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/bapps-prod'
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: ${{ secrets.SSV_WEB_AWS_IAM_ROLE }}
+          aws-region: ${{ vars.AWS_REGION }}
+
       # <app-pre.stage.ssv.network> pre-stage
       - name: Run stage webapp build
         if: github.ref == 'refs/heads/pre-stage-update-ci'
@@ -112,13 +119,6 @@ jobs:
           BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
-
-      - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/pre-stage-update-ci'
-        uses: aws-actions/configure-aws-credentials@v3
-        with:
-          role-to-assume: ${{ secrets.SSV_WEB_AWS_IAM_ROLE }}
-          aws-region: ${{ vars.AWS_REGION }}
 
       - name: Upload files to S3
         if: github.ref == 'refs/heads/pre-stage-update-ci'
@@ -143,18 +143,11 @@ jobs:
           BLOCKNATIVE_KEY: ${{ secrets.BLOCKNATIVE_KEY }}
           LINK_SSV_DEV_DOCS: ${{ secrets.LINK_SSV_DEV_DOCS }}
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
-
-      - name: Deploy stage webapp
+      
+      - name: Upload files to S3
         if: github.ref == 'refs/heads/stage'
-        uses: jakejarvis/s3-sync-action@v0.5.0
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: "build/"
-          AWS_REGION: "us-west-2"
-          AWS_S3_BUCKET: ${{ secrets.STAGE_AWS_S3_BUCKET_V4 }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.STAGE_AWS_SECRET_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.STAGE_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp ./build s3://${{ secrets.SSV_WEB_STAGE_AWS_S3_BUCKET }} --recursive
       # </app.stage.ssv.network>
 
       # <app.ssv.network>
@@ -177,17 +170,10 @@ jobs:
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Deploy prod webapp
+      - name: Upload files to S3
         if: github.ref == 'refs/heads/main'
-        uses: jakejarvis/s3-sync-action@v0.5.0
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: "build/"
-          AWS_REGION: "us-west-2"
-          AWS_S3_BUCKET: ${{ secrets.PROD_AWS_S3_BUCKET_V4 }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_SECRET_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp ./build s3://${{ secrets.SSV_WEB_MAIN_AWS_S3_BUCKET }} --recursive
       # </app.ssv.network>
 
       # <ba-app.ssv.network>
@@ -210,15 +196,8 @@ jobs:
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_PROD }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
 
-      - name: Deploy prod ba-app webapp
+      - name: Upload files to S3
         if: github.ref == 'refs/heads/bapps-prod'
-        uses: jakejarvis/s3-sync-action@v0.5.0
-        with:
-          args: --acl public-read --follow-symlinks --delete
-        env:
-          SOURCE_DIR: "build/"
-          AWS_REGION: "us-west-2"
-          AWS_S3_BUCKET: ${{ secrets.PROD_AWS_S3_BUCKET_BA_APP }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.PROD_AWS_SECRET_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+        run: |
+          aws s3 cp ./build s3://${{ secrets.SSV_WEB_BAPP_PROD_AWS_S3_BUCKET }} --recursive
        # </ba-app.ssv.network>

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -96,7 +96,7 @@ jobs:
         run: npx semantic-release
 
       - name: Configure AWS credentials
-        if: github.ref == 'refs/heads/pre-stage-update-ci' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/bapps-prod'
+        if: github.ref == 'refs/heads/pre-stage' || github.ref == 'refs/heads/stage' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/bapps-prod'
         uses: aws-actions/configure-aws-credentials@v3
         with:
           role-to-assume: ${{ secrets.SSV_WEB_AWS_IAM_ROLE }}
@@ -104,7 +104,7 @@ jobs:
 
       # <app-pre.stage.ssv.network> pre-stage
       - name: Run stage webapp build
-        if: github.ref == 'refs/heads/pre-stage-update-ci'
+        if: github.ref == 'refs/heads/pre-stage'
         run: >
           GAS_PRICE="${{ env.GAS_PRICE }}"
           GAS_LIMIT="${{ env.GAS_LIMIT }}"
@@ -121,7 +121,7 @@ jobs:
           MIXPANEL_TOKEN: ${{ secrets.MIXPANEL_TOKEN_STAGE }}
 
       - name: Upload files to S3
-        if: github.ref == 'refs/heads/pre-stage-update-ci'
+        if: github.ref == 'refs/heads/pre-stage'
         run: |
           aws s3 cp ./build s3://${{ secrets.SSV_WEB_PRE_STAGE_AWS_S3_BUCKET }} --recursive
       # </app-pre.stage.ssv.network>


### PR DESCRIPTION
* remove trigger on PRs - the default trigger is on every push, and having the extra pull_request entry causes it to run 2 times in case it is a push to a branch with a PR
* remove commented-out entries - we can add later if needed
* replace the AWSA auth system with OIDC - no more need for direct static AWS keys
* replace deprecated aws s3 sync action